### PR TITLE
Fix codeql scanning workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -4,7 +4,9 @@ name: "CodeQL"
 # yamllint disable-line rule:truthy
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
   schedule:
     - cron: "30 1 * * 0"
 


### PR DESCRIPTION
# Proposed Changes

Or else dependabot will have failed builds each time, which is just annoying.
