### PR TITLE
Fix string formatting issue

### DIFF
--- a/src/vehicle/const.py
+++ b/src/vehicle/const.py
@@ -1,9 +1,9 @@
 """Asynchronous Python client providing RDW vehicle information."""
 
-from enum import Enum, StrEnum
+from enum import Enum
 
 
-class Dataset(StrEnum):
+class Dataset(str, Enum):
     """Enum holding the RDW dataset identifiers for the Socrata API."""
 
     PLATED_VEHICLES = "m9d7-ebf2"

--- a/src/vehicle/const.py
+++ b/src/vehicle/const.py
@@ -1,9 +1,9 @@
 """Asynchronous Python client providing RDW vehicle information."""
 
-from enum import Enum
+from enum import Enum, StrEnum
 
 
-class Dataset(str, Enum):
+class Dataset(StrEnum):
     """Enum holding the RDW dataset identifiers for the Socrata API."""
 
     PLATED_VEHICLES = "m9d7-ebf2"

--- a/src/vehicle/rdw.py
+++ b/src/vehicle/rdw.py
@@ -42,7 +42,7 @@ class RDW:
 
     async def _request(
         self,
-        dataset: str,
+        dataset: Dataset,
         *,
         data: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -68,7 +68,7 @@ class RDW:
             RDWError: Received an unexpected response from the Socrata API.
         """
         version = metadata.version(__package__)
-        url = URL("https://opendata.rdw.nl/resource/").join(URL(f"{dataset}.json"))
+        url = URL("https://opendata.rdw.nl/resource/").join(URL(f"{dataset.value}.json"))
 
         headers = {
             "User-Agent": f"PythonVehicle/{version}",

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -14,7 +14,6 @@ from vehicle import (
     VehicleOdometerJudgement,
     VehicleType,
 )
-from vehicle.const import Dataset
 
 from . import load_fixture
 
@@ -25,7 +24,7 @@ async def test_vehicle_data(  # pylint: disable=too-many-statements
     """Test getting Vehicle information."""
     aresponses.add(
         "opendata.rdw.nl",
-        f"/resource/{Dataset.PLATED_VEHICLES}.json",
+        "/resource/m9d7-ebf2.json",
         "GET",
         aresponses.Response(
             status=200,
@@ -65,7 +64,7 @@ async def test_vehicle_data(  # pylint: disable=too-many-statements
 
     aresponses.add(
         "opendata.rdw.nl",
-        f"/resource/{Dataset.PLATED_VEHICLES}.json",
+        "/resource/m9d7-ebf2.json",
         "GET",
         aresponses.Response(
             status=200,
@@ -108,7 +107,7 @@ async def test_no_vehicle(aresponses: ResponsesMockServer) -> None:
     """Test getting non-existing Vehicle."""
     aresponses.add(
         "opendata.rdw.nl",
-        f"/resource/{Dataset.PLATED_VEHICLES}.json",
+        "/resource/m9d7-ebf2.json",
         "GET",
         aresponses.Response(
             status=200,

--- a/tests/test_rdw.py
+++ b/tests/test_rdw.py
@@ -7,6 +7,7 @@ import pytest
 from aresponses import Response, ResponsesMockServer
 
 from vehicle import RDW
+from vehicle.const import Dataset
 from vehicle.exceptions import RDWConnectionError, RDWError
 
 

--- a/tests/test_rdw.py
+++ b/tests/test_rdw.py
@@ -7,7 +7,6 @@ import pytest
 from aresponses import Response, ResponsesMockServer
 
 from vehicle import RDW
-from vehicle.const import Dataset
 from vehicle.exceptions import RDWConnectionError, RDWError
 
 
@@ -15,7 +14,7 @@ async def test_json_request(aresponses: ResponsesMockServer) -> None:
     """Test JSON response is handled correctly."""
     aresponses.add(
         "opendata.rdw.nl",
-        f"/resource/{Dataset.PLATED_VEHICLES}.json",
+        "/resource/m9d7-ebf2.json",
         "GET",
         aresponses.Response(
             status=200,
@@ -34,7 +33,7 @@ async def test_internal_session(aresponses: ResponsesMockServer) -> None:
     """Test JSON response is handled correctly."""
     aresponses.add(
         "opendata.rdw.nl",
-        f"/resource/{Dataset.PLATED_VEHICLES}.json",
+        "/resource/m9d7-ebf2.json",
         "GET",
         aresponses.Response(
             status=200,
@@ -58,7 +57,7 @@ async def test_timeout(aresponses: ResponsesMockServer) -> None:
 
     aresponses.add(
         "opendata.rdw.nl",
-        f"/resource/{Dataset.PLATED_VEHICLES}.json",
+        "/resource/m9d7-ebf2.json",
         "GET",
         response_handler,
     )
@@ -73,7 +72,7 @@ async def test_http_error400(aresponses: ResponsesMockServer) -> None:
     """Test HTTP 404 response handling."""
     aresponses.add(
         "opendata.rdw.nl",
-        f"/resource/{Dataset.PLATED_VEHICLES}.json",
+        "/resource/m9d7-ebf2.json",
         "GET",
         aresponses.Response(text="OMG PUPPIES!", status=404),
     )
@@ -88,7 +87,7 @@ async def test_unexpected_response(aresponses: ResponsesMockServer) -> None:
     """Test unexpected response handling."""
     aresponses.add(
         "opendata.rdw.nl",
-        f"/resource/{Dataset.PLATED_VEHICLES}.json",
+        "/resource/m9d7-ebf2.json",
         "GET",
         aresponses.Response(text="OMG PUPPIES!", status=200),
     )


### PR DESCRIPTION
# Proposed Changes

Apparently when formatting a string, a `(str, Enum)` doesn't get it's value, but the whole name. This resulted in requesting `/resource/{DataSet.PLATED_VEHICLES}.json` instead of `/resource/m9d7-ebf2.json`. Since the dataset hasn't changed in the last 2 years (according to git blame) I hardcoded the dataset in the tests to avoid this in the future.

Update: instead of passing str, we now pass the dataset

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
