### PR TITLE
nullable ascription date when vehicle is imported but not sold yet

### DIFF
--- a/src/vehicle/models.py
+++ b/src/vehicle/models.py
@@ -52,7 +52,7 @@ class Vehicle(BaseModel):
     """
 
     apk_expiration: date | None = Field(None, alias="vervaldatum_apk")
-    ascription_date: date = Field(..., alias="datum_tenaamstelling")
+    ascription_date: date | None = Field(None, alias="datum_tenaamstelling")
     ascription_possible: bool | None = Field(None, alias="tenaamstellen_mogelijk")
     brand: str = Field(..., alias="merk")
     energy_label: str | None = Field(None, alias="zuinigheidslabel")


### PR DESCRIPTION
# Proposed Changes

> Ascription date is nullable

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
